### PR TITLE
feat(actuator): add Spring Security configuration for actuator endpoi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>dev.sitconsulting</groupId>
     <artifactId>sit-metrics-autoconfiguration</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 
     <organization>
         <name>S-IT Application Engineering &amp; Consulting GmbH</name>
@@ -57,6 +57,11 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/dev/sitconsulting/library/spring/ActuatorSecurityConfiguration.java
+++ b/src/main/java/dev/sitconsulting/library/spring/ActuatorSecurityConfiguration.java
@@ -1,0 +1,28 @@
+package dev.sitconsulting.library.spring;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@AutoConfiguration
+@ConditionalOnClass(HttpSecurity.class) // Wird nur aktiv, wenn Spring Security im Projekt ist
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class ActuatorSecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/actuator/**") // Gilt nur für Actuator-Pfade
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()    // Erlaube alles unter /actuator/
+                )
+                .csrf(csrf -> csrf.disable())    // Deaktiviere CSRF für diese Endpunkte
+                .httpBasic(basic -> basic.disable())
+                .formLogin(form -> form.disable());
+
+        return http.build();
+    }
+}

--- a/src/main/java/dev/sitconsulting/library/spring/MetricsAutoConfiguration.java
+++ b/src/main/java/dev/sitconsulting/library/spring/MetricsAutoConfiguration.java
@@ -1,5 +1,6 @@
 package dev.sitconsulting.library.spring;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -9,33 +10,67 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
 
+/**
+ * Auto-configuration for application metrics.
+ * Provides build information metrics that can be customized via properties:
+ * <p>
+ * Application configuration (in application.properties/yaml):
+ * <pre>
+ * app.build.version=${project.version}
+ * app.build.timestamp=${maven.build.timestamp:0}
+ * </pre>
+ */
 @Configuration
 @Slf4j
 public class MetricsAutoConfiguration {
+
     @Value("${spring.application.name}")
     private String appName;
 
     @Bean
-    public MeterRegistryCustomizer<MeterRegistry> meterRegistryDefaultsCustomizer() {
-        return registry -> registry.config()
-                .commonTags(
-                        "application", appName,
-                        "host", getHost()
-                ).meterFilter(
-                        new MeterFilter() {
-                            @Override
-                            public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-                                return DistributionStatisticConfig.builder()
-                                        .percentiles(0.99d, 0.95d, 0.90d, 0.75d)
-                                        .build()
-                                        .merge(config);
-                            }
+    public MeterRegistryCustomizer<MeterRegistry> meterRegistryDefaultsCustomizer(
+            Environment environment) {
+        BuildInfo bootInfo = getBuildInfoFromOwnPackage();
+
+        log.info("Configuring meter registry with app name: {}, build version: {}", appName, bootInfo.version);
+
+        return registry -> {
+            // Add common tags
+            registry.config().commonTags(
+                    "application", appName,
+                    "host", getHost()
+            );
+
+            // Register build_info gauge with tags for filtering
+            Gauge.builder("buildInfo", bootInfo, v -> 1.0)
+                    .description("Build information")
+                    .tag("version", bootInfo.version)
+                    .tag("buildTime", bootInfo.time)
+                    .register(registry);
+
+            // Configure percentiles for all metrics
+            registry.config().meterFilter(
+                    new MeterFilter() {
+                        @Override
+                        public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                            return DistributionStatisticConfig.builder()
+                                    .percentiles(0.99d, 0.95d, 0.90d, 0.75d)
+                                    .build()
+                                    .merge(config);
                         }
-                );
+                    }
+            );
+        };
     }
 
     private static String getHost() {
@@ -45,6 +80,34 @@ public class MetricsAutoConfiguration {
         } catch (UnknownHostException e) {
             log.warn("Could not resolve host name, using fallback...");
             return "<unknown>";
+        }
+    }
+
+    private static BuildInfo getBuildInfoFromOwnPackage() {
+        try (InputStream is = MetricsAutoConfiguration.class.getClassLoader()
+                .getResourceAsStream("META-INF/build-info.properties")) {
+            if (is != null) {
+                Properties props = new Properties();
+                props.load(is);
+                String version = props.getProperty("build.version");
+                String time = props.getProperty("build.time");
+                if (version != null) {
+                    return new BuildInfo(version, time);
+                }
+            }
+        } catch (IOException | NumberFormatException e) {
+            log.debug("Could not load build-info.properties", e);
+        }
+        return new BuildInfo("unknown", LocalDateTime.MIN.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    }
+
+    private static class BuildInfo {
+        final String version;
+        final String time;
+
+        BuildInfo(String version, String time) {
+            this.version = version;
+            this.time = time;
         }
     }
 }

--- a/src/main/java/dev/sitconsulting/library/spring/MetricsEnvironmentPostProcessor.java
+++ b/src/main/java/dev/sitconsulting/library/spring/MetricsEnvironmentPostProcessor.java
@@ -15,10 +15,14 @@ public class MetricsEnvironmentPostProcessor implements EnvironmentPostProcessor
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
         Map<String, Object> defaultProperties = new HashMap<>();
         defaultProperties.put("management.metrics.export.prometheus.enabled", "true");
-        defaultProperties.put("management.security.enabled", "false");
         defaultProperties.put("management.server.ssl.enabled", "false");
         defaultProperties.put("management.endpoints.web.exposure.include",
                 "beans,caches,conditions,configprops,env,health,info,liquibase,mappings,prometheus");
+        defaultProperties.put("management.endpoints.enabled-by-default", "true");
+        defaultProperties.put("management.info.build.enabled", "false");
+
+        //Test:
+        defaultProperties.put("management.info.build.enabled", "false");
 
         MapPropertySource target = new MapPropertySource(PROPERTY_SOURCE_NAME, defaultProperties);
         environment.getPropertySources().addLast(target);

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  dev.sitconsulting.library.spring.MetricsAutoConfiguration
-
-org.springframework.boot.env.EnvironmentPostProcessor=\
-  dev.sitconsulting.library.spring.MetricsEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=dev.sitconsulting.library.spring.MetricsEnvironmentPostProcessor

--- a/src/main/resources/META-INF/spring/dev.sitconsulting.library.spring.ActuatorSecurityConfiguration.imports
+++ b/src/main/resources/META-INF/spring/dev.sitconsulting.library.spring.ActuatorSecurityConfiguration.imports
@@ -1,0 +1,1 @@
+dev.sitconsulting.library.spring.ActuatorSecurityConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+dev.sitconsulting.library.spring.MetricsAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
@@ -1,0 +1,1 @@
+dev.sitconsulting.library.spring.MetricsEnvironmentPostProcessor


### PR DESCRIPTION
…nts, update for spring boot 3.x

- Add ActuatorSecurityConfiguration auto-configuration class
- Configure security to permit all actuator endpoints without authentication
- Disable CSRF, HTTP Basic, and Form Login for /actuator/**
- Enhance MetricsAutoConfiguration with build_info gauge from build-info.properties
- Update to Spring Boot 3.x auto-configuration import format
- Add spring-boot-starter-security dependency

BREAKING CHANGE: Actuator endpoints now have explicit security configuration. Projects using custom security may need to adjust their configuration.